### PR TITLE
Add clippy for static analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adh-client-creds-rust"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adh-client-creds-rust"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["AVEVA <samples@osisoft.com>"]
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 1.0.2 / 2022-06-27
+
+- Add static code analysis (clippy) to pipeline
+
 ## 1.0.1 / 2022-06-17
 
 - Updated dependencies

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub. The samples also work on OSIsoft Cloud Services unless otherwise noted. |  
 | -----------------------------------------------------------------------------------------------|
 
-**Version:** 1.0.1
+**Version:** 1.0.2
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-authentication_client_credentials_simple-rust?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=4476&branchName=main)
 

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -55,20 +55,12 @@ jobs:
           source $HOME/.cargo/env
           cargo test --all
         displayName: 'Run tests'
+        condition: always()
 
       - script: |
           source $HOME/.cargo/env
           cargo clippy --all
         displayName: 'Run clippy'
-
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: JUnit
-          testResultsFiles: '*.xml'
-          failTaskOnFailedTests: true
-          searchFolder: '$(Build.SourcesDirectory)/TestResults'
-          testRunTitle: '$(Agent.JobName) on Linux'
-        displayName: 'Publish test results'
         condition: always()
 
   - template: '/miscellaneous/build_templates/code-analysis.yml@templates'

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -56,6 +56,12 @@ jobs:
           cargo test --all
         displayName: 'Run tests'
 
+      - script: rustup component add clippy
+        displayName: 'Install clippy'
+
+      - script: cargo clippy --all
+        displayName: 'Run clippy'
+
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: JUnit

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -56,10 +56,9 @@ jobs:
           cargo test --all
         displayName: 'Run tests'
 
-      - script: rustup component add clippy
-        displayName: 'Install clippy'
-
-      - script: cargo clippy --all
+      - script: |
+          source $HOME/.cargo/env
+          cargo clippy --all
         displayName: 'Run clippy'
 
       - task: PublishTestResults@2

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,6 @@ mod tests {
         let status_code = crate::get_tenant_info()
             .await
             .expect("Problem obtaining tenant info");
-        assert_eq!(status_code, reqwest::StatusCode::Forbidden);
+        assert_eq!(status_code, reqwest::StatusCode::OK);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,6 @@ mod tests {
         let status_code = crate::get_tenant_info()
             .await
             .expect("Problem obtaining tenant info");
-        assert_eq!(status_code, reqwest::StatusCode::OK);
+        assert_eq!(status_code, reqwest::StatusCode::Forbidden);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,6 @@ mod tests {
         let status_code = crate::get_tenant_info()
             .await
             .expect("Problem obtaining tenant info");
-        assert_eq!(status_code, reqwest::StatusCode::Ok);
+        assert_eq!(status_code, reqwest::StatusCode::OK);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ async fn get_tenant_info() -> Result<reqwest::StatusCode, reqwest::Error> {
     let wellknown_info: WellKnownInfo = client.get(wellknown_endpoint).send().await?.json().await?;
 
     // Step 3: use the client ID and Secret to get the needed bearer token
-    let mut params = HashMap::new();
+    let mut params = std::collections::HashMap::new();
     params.insert("client_id", appsettings.client_id);
     params.insert("client_secret", appsettings.client_secret);
     params.insert("grant_type", "client_credentials".to_string());
@@ -89,6 +89,6 @@ mod tests {
         let status_code = crate::get_tenant_info()
             .await
             .expect("Problem obtaining tenant info");
-        assert_eq!(status_code, reqwest::StatusCode::Forbidden);
+        assert_eq!(status_code, reqwest::StatusCode::Ok);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ async fn get_tenant_info() -> Result<reqwest::StatusCode, reqwest::Error> {
     let wellknown_info: WellKnownInfo = client.get(wellknown_endpoint).send().await?.json().await?;
 
     // Step 3: use the client ID and Secret to get the needed bearer token
-    let mut params = std::collections::HashMap::new();
+    let mut params = HashMap::new();
     params.insert("client_id", appsettings.client_id);
     params.insert("client_secret", appsettings.client_secret);
     params.insert("grant_type", "client_credentials".to_string());
@@ -89,6 +89,6 @@ mod tests {
         let status_code = crate::get_tenant_info()
             .await
             .expect("Problem obtaining tenant info");
-        assert_eq!(status_code, reqwest::StatusCode::OK);
+        assert_eq!(status_code, reqwest::StatusCode::Forbidden);
     }
 }


### PR DESCRIPTION
On the initial release, static code analysis (via cargo clippy) was not implemented. This PR adds it as a task to the pipeline. The clippy task will run even if the tests fail, which can be helpful if the test fails for any syntax/formatting reasons. The pipeline also had the publish test results task removed because this task was not doing anything for this sample; the tests fail and succeed within the test task itself rather than through the junit xml file.